### PR TITLE
APIS-746: wordbreak

### DIFF
--- a/app/controllers/DevelopersController.scala
+++ b/app/controllers/DevelopersController.scala
@@ -93,10 +93,4 @@ trait DevelopersController extends FrontendController with GatekeeperAuthWrapper
         }
       }
   }
-
-  def submitDeveloperFilter = requiresRole(Role.APIGatekeeper) {
-    implicit request => implicit hc =>
-      val form = developerFilterForm.bindFromRequest.get
-      Future.successful(redirect(Option(form.filter), Option(form.status), form.pageNumber, form.pageSize))
-    }
 }

--- a/app/model/Forms.scala
+++ b/app/model/Forms.scala
@@ -26,14 +26,4 @@ package object Forms {
       "userName" -> nonEmptyText,
       "password" -> nonEmptyText
     )(LoginDetails.make)(LoginDetails.unmake))
-
-  val developerFilterForm: Form[DeveloperFilterForm] = Form(
-    mapping(
-      "filter" -> text(maxLength = 70),
-      "status" -> text(maxLength = 10),
-      "pageNumber" -> number(),
-      "pageSize" -> number()
-    )(DeveloperFilterForm.apply)(DeveloperFilterForm.unapply))
 }
-
-case class DeveloperFilterForm(filter: String, status: String, pageNumber: Int, pageSize: Int)

--- a/app/views/developers/developers.scala.html
+++ b/app/views/developers/developers.scala.html
@@ -36,7 +36,7 @@
 
     @tabList(activeTab = 1)
 
-    <form action="developers" method="post">
+    <form action="@routes.DevelopersController.developersPage(filter, status, users.pageNumber, users.pageSize).url" method="get">
         <div class="grid-layout" style="margin-left:0">
             <div class="grid-layout__column--1-3">
                 <div class="form-group">
@@ -128,7 +128,6 @@
 
         <input type="hidden" name="pageNumber" value="@users.pageNumber"/>
 
-        @helper.CSRF.formField
     </form>
 
     @if(users.length > 0) {

--- a/app/views/developers/developers.scala.html
+++ b/app/views/developers/developers.scala.html
@@ -12,6 +12,24 @@
 
 <article class="content__body full-width">
 
+    <style>
+        .developer-list tr {
+          word-break: break-all;
+        }
+
+        .input-select {
+           margin: 0;
+        }
+
+        .input-select--large {
+          width: 85%;
+        }
+
+        .developer-status {
+          min-width: 150px;
+        }
+    </style>
+
     <header>
         <h1>Dashboard</h1>
     </header>
@@ -23,8 +41,8 @@
             <div class="grid-layout__column--1-3">
                 <div class="form-group">
                     <label class="form-label bold" for="filter">Filter by API Subscription
-                        <select class="form-control" id="filter" name="filter"
-                                value="@filter" onchange="this.form.submit()" style="margin:0;width:85%">
+                        <select class="form-control input-select input-select--large" id="filter" name="filter"
+                                value="@filter" onchange="this.form.submit()">
                             <option @if(filter == None || filter == Some("ALL")) {selected} value="ALL">ALL</option>
                             <option @if(filter == Some("NONE")) {selected} value="NONE">NONE</option>
 
@@ -46,8 +64,8 @@
             <div class="grid-layout__column--1-3">
                 <div class="form-group">
                     <label class="form-label bold" for="status">Filter by Status
-                        <select class="form-control" id="status" name="status"
-                                value="@status" onchange="this.form.submit()" style="margin:0;width:85%">
+                        <select class="form-control input-select input-select--large" id="status" name="status"
+                                value="@status" onchange="this.form.submit()">
                             @for((value,label) <- Map("ALL" -> "ALL", "VERIFIED" -> "Verified", "UNVERIFIED" -> "Unverified")) {
                                 <option value="@value" @if(Some(value) == status){selected}>@label</option>
                             }
@@ -59,8 +77,8 @@
             <div class="grid-layout__column--1-3">
                 <div class="form-group">
                     <label class="form-label bold" for="pageSize">Show Rows
-                        <select class="form-control input--small" id="pageSize" name="pageSize"
-                                value="@users.pageSize" onchange="this.form.submit()" style="margin:0">
+                        <select class="form-control input--small input-select" id="pageSize" name="pageSize"
+                                value="@users.pageSize" onchange="this.form.submit()">
                             @for(n <- List(10,20,100)) {
                                 <option value="@n" @if(users.pageSize == n){selected}>@n</option>
                             }
@@ -70,7 +88,7 @@
             </div>
         </div>
 
-        <table>
+        <table class="developer-list">
             <caption class="visuallyhidden">Table showing all developers</caption>
             <thead>
                 <tr role="row">
@@ -82,9 +100,9 @@
             <tbody>
             @for(developer <- users.projection) {
                 <tr role="row">
-                    <td>@developer.fullName</td>
-                    <td>@developer.email</td>
-                    <td class="text--right hard--right">
+                    <td class="developer-name">@developer.fullName</td>
+                    <td class="developer-email">@developer.email</td>
+                    <td class="developer-status text--right hard--right">
                         @defining(developer.verified match {
                             case Some(true) => ("status status--verified", "verified")
                             case _ => ("status status--not-verified", "not yet verified")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,7 +11,6 @@ GET         /review                                controllers.DashboardControll
 GET         /approved                              controllers.DashboardController.approvedApplicationPage(id: String)
 
 GET         /developers                            controllers.DevelopersController.developersPage(filter: Option[String] ?= None, status: Option[String] ?= None, pageNumber: Int ?= 1, pageSize: Int ?= 10)
-POST        /developers                            controllers.DevelopersController.submitDeveloperFilter
 
 ->          /template                              template.Routes
 

--- a/test/unit/controllers/DevelopersControllerSpec.scala
+++ b/test/unit/controllers/DevelopersControllerSpec.scala
@@ -60,12 +60,11 @@ class DevelopersControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
       implicit val decryptedStringFormats = JsonStringDecryption
       implicit val format = Json.format[LoginDetails]
 
-      val csrfToken = "csrfToken" -> SignedTokenProvider.generateToken
       val authToken = SessionKeys.authToken -> "some-bearer-token"
       val userToken = GatekeeperSessionKeys.LoggedInUser -> "userName"
 
-      val aLoggedInRequest = FakeRequest().withSession(csrfToken, authToken, userToken)
-      val aLoggedOutRequest = FakeRequest().withSession(csrfToken)
+      val aLoggedInRequest = FakeRequest().withSession(authToken, userToken)
+      val aLoggedOutRequest = FakeRequest().withSession()
 
       val userName = "userName"
     }
@@ -145,6 +144,5 @@ class DevelopersControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
         collaborators.foreach(c => bodyOf(result) should include(c.emailAddress))
       }
     }
-
   }
 }


### PR DESCRIPTION
* Add inline style for word break, to cater for long email addresses - see screenshot below (awaiting guidance feedback from UX/Frontend guys about best way to have custom CSS outside ASSETS_FRONTEND)
* Refactor developer list submit - was POST, but changed to GET, which meant a good deal of code could be completely removed.

![screenshot from 2016-10-07 12-20-46](https://cloud.githubusercontent.com/assets/1915543/19188300/d009f222-8c88-11e6-9352-b58b699adbab.png)
