### PR TITLE
APIS-744, APIS-751: Unregistered Collaborators & Filter by NONE bugfix

### DIFF
--- a/app/connectors/ApplicationConnector.scala
+++ b/app/connectors/ApplicationConnector.scala
@@ -70,6 +70,14 @@ trait ApplicationConnector {
       }
   }
 
+  def fetchAllApplicationsWithNoSubscriptions()(implicit hc: HeaderCarrier): Future[Seq[ApplicationResponse]] = {
+    http.GET[Seq[ApplicationResponse]](s"$applicationBaseUrl/application?noSubscriptions=true")
+      .recover {
+	case e: Upstream5xxResponse => throw new FetchApplicationsFailed
+      }
+  }
+
+
   def fetchAllApplications()(implicit hc: HeaderCarrier): Future[Seq[ApplicationResponse]] = {
     http.GET[Seq[ApplicationResponse]](s"$applicationBaseUrl/application")
       .recover {

--- a/app/model/Filters.scala
+++ b/app/model/Filters.scala
@@ -19,20 +19,25 @@ package model
 
 sealed trait ApiFilter[+A]
 case class Value[A](a: A) extends ApiFilter[A]
+case object NoApplications extends ApiFilter[Nothing]
 case object NoSubscriptions extends ApiFilter[Nothing]
+case object OneOrMoreSubscriptions extends ApiFilter[Nothing]
 case object AllUsers extends ApiFilter[Nothing]
 
 case object ApiFilter extends ApiFilter[String] {
   def apply(value: Option[String]): ApiFilter[String] = {
     value match {
-      case Some("ALL") | None => AllUsers
-      case Some("NONE") => NoSubscriptions
+      case Some("ALL") | Some("") | None => AllUsers
+      case Some("ANYSUB") => OneOrMoreSubscriptions
+      case Some("NOSUB") => NoSubscriptions
+      case Some("NOAPP") => NoApplications
       case Some(flt) => Value(flt)
     }
   }
 }
 
 sealed trait StatusFilter
+case object UnregisteredStatus extends StatusFilter
 case object UnverifiedStatus extends StatusFilter
 case object VerifiedStatus extends StatusFilter
 case object AnyStatus extends StatusFilter
@@ -40,6 +45,7 @@ case object AnyStatus extends StatusFilter
 case object StatusFilter extends StatusFilter {
   def apply(value: Option[String]): StatusFilter = {
     value match {
+      case Some("UNREGISTERED") => UnregisteredStatus
       case Some("UNVERIFIED") => UnverifiedStatus
       case Some("VERIFIED") => VerifiedStatus
       case _ => AnyStatus

--- a/app/model/Model.scala
+++ b/app/model/Model.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 
 import model.CollaboratorRole.CollaboratorRole
 import model.State.State
+import model.User.UserStatus
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 import uk.gov.hmrc.crypto.json.{JsonDecryptor, JsonEncryptor}
@@ -117,19 +118,26 @@ object ApplicationWithHistory {
 
 case class ApplicationWithUpliftRequest(id: UUID, name: String, submittedOn: DateTime, state: State)
 
-case class User(email: String, firstName: String, lastName: String, verified: Option[Boolean], registered: Option[Boolean] = Some(true)) extends Ordered[User] {
+case class User(email: String, firstName: String, lastName: String, verified: Option[Boolean]) extends Ordered[User] {
   val fullName = s"$firstName $lastName"
   val sortField = s"${lastName.trim().toLowerCase()} ${firstName.trim().toLowerCase()}"
+  val status: UserStatus = verified match {
+    case Some(true) => VerifiedStatus
+    case Some(false) => UnverifiedStatus
+    case None => UnregisteredStatus
+  }
   def compare(that: User) = this.sortField.compare(that.sortField)
-}
-
-case object UnregisteredCollaborator {
-  def apply(email: String) = User(email, "n/a", "", verified = None, registered = None)
 }
 
 object User {
   implicit val format = Json.format[User]
+  type UserStatus = StatusFilter
 }
+
+case object UnregisteredCollaborator {
+  def apply(email: String) = User(email, "n/a", "", verified = None)
+}
+
 
 object ApplicationWithUpliftRequest {
 

--- a/app/views/developers/developers.scala.html
+++ b/app/views/developers/developers.scala.html
@@ -40,24 +40,27 @@
         <div class="grid-layout" style="margin-left:0">
             <div class="grid-layout__column--1-3">
                 <div class="form-group">
-                    <label class="form-label bold" for="filter">Filter by API Subscription
-                        <select class="form-control input-select input-select--large" id="filter" name="filter"
-                                value="@filter" onchange="this.form.submit()">
-                            <option @if(filter == None || filter == Some("ALL")) {selected} value="ALL">ALL</option>
-                            <option @if(filter == Some("NONE")) {selected} value="NONE">NONE</option>
+                    @defining(ApiFilter(filter)) { apiFilter =>
+                        <label class="form-label bold" for="filter">Filter by API Subscription
+                            <select class="form-control input-select input-select--large" id="filter" name="filter"
+                                    value="@filter" onchange="this.form.submit()">
 
-                            @for((status, versions) <- apis) {
-                                <optgroup label="@status">
-                                    @for(version <- versions.sortBy(v => v.name.toLowerCase)) {
-                                        @defining(filter match {
-                                            case Some(f) if f == version.apiIdentifier.context => "selected"
-                                            case _ => ""
-                                        }) { selected => <option @selected value="@version.apiIdentifier.context">@version.name (@version.apiIdentifier.version)</option> }
-                                    }
-                                </optgroup>
-                            }
-                        </select>
-                    </label>
+                                <option @if(apiFilter == AllUsers) {selected} value="ALL">All users</option>
+                                <option @if(apiFilter == OneOrMoreSubscriptions) {selected} value="ANYSUB">One or more subscriptions</option>
+                                <option @if(apiFilter == NoSubscriptions) {selected} value="NOSUB">No subscriptions</option>
+                                <option @if(apiFilter == NoApplications) {selected} value="NOAPP">No applications</option>
+
+                                @for((status, versions) <- apis) {
+                                    <optgroup label="@status">
+                                        @for(version <- versions.sortBy(v => v.name.toLowerCase)) {
+                                            <option @if(apiFilter == Value(version.apiIdentifier.context)) {selected}
+                                                    value="@version.apiIdentifier.context">@version.name (@version.apiIdentifier.version)</option>
+                                        }
+                                    </optgroup>
+                                }
+                            </select>
+                        </label>
+                    }
                 </div>
             </div>
 
@@ -66,7 +69,7 @@
                     <label class="form-label bold" for="status">Filter by Status
                         <select class="form-control input-select input-select--large" id="status" name="status"
                                 value="@status" onchange="this.form.submit()">
-                            @for((value,label) <- Map("ALL" -> "ALL", "VERIFIED" -> "Verified", "UNVERIFIED" -> "Unverified")) {
+                            @for((value,label) <- Map("ALL" -> "All", "VERIFIED" -> "Verified", "UNVERIFIED" -> "Unverified", "UNREGISTERED" -> "Unregistered")) {
                                 <option value="@value" @if(Some(value) == status){selected}>@label</option>
                             }
                         </select>
@@ -103,9 +106,10 @@
                     <td class="developer-name">@developer.fullName</td>
                     <td class="developer-email">@developer.email</td>
                     <td class="developer-status text--right hard--right">
-                        @defining(developer.verified match {
-                            case Some(true) => ("status status--verified", "verified")
-                            case _ => ("status status--not-verified", "not yet verified")
+                        @defining(developer.status match {
+                            case VerifiedStatus => ("status status--verified", "verified")
+                            case UnverifiedStatus => ("status status--not-verified", "not yet verified")
+                            case UnregisteredStatus => ("status status--not-verified", "not registered")
                         }) { case(cssStyle, text) => <span class="@cssStyle">@text</td> }
                 </tr>
             }

--- a/test/unit/connectors/DeveloperConnectorSpec.scala
+++ b/test/unit/connectors/DeveloperConnectorSpec.scala
@@ -51,7 +51,7 @@ class DeveloperConnectorSpec extends UnitSpec with Matchers with ScalaFutures wi
 
     def encode(str: String) = URLEncoder.encode(str, "UTF-8")
 
-    def aUserResponse(email: String) = User(email, "first", "last", Some(false), None)
+    def aUserResponse(email: String) = User(email, "first", "last", Some(false))
 
     def verifyUserResponse(userResponse: User,
                            expectedEmail: String, expectedFirstName: String, expectedLastName: String) = {

--- a/test/unit/controllers/DeveloperViewSpec.scala
+++ b/test/unit/controllers/DeveloperViewSpec.scala
@@ -24,8 +24,8 @@ class DeveloperViewSpec extends PlaySpec {
 
   "developersView" must {
     val users = Seq(
-      User("sample@email.com", "Sample", "Email", Some(false), None),
-      User("another@email.com", "Sample2", "Email", Some(true), None),
+      User("sample@email.com", "Sample", "Email", Some(false)),
+      User("another@email.com", "Sample2", "Email", Some(true)),
       UnregisteredCollaborator("something@email.com"))
 
     "list all developers" in new App {

--- a/test/unit/services/DeveloperServiceSpec.scala
+++ b/test/unit/services/DeveloperServiceSpec.scala
@@ -46,147 +46,135 @@ class DeveloperServiceSpec extends UnitSpec with MockitoSugar {
       val developerConnector = mock[DeveloperConnector]
       val apiDefinitionConnector = mock[ApiDefinitionConnector]
     }
-
-    val users = Seq(
-      user("Bob", false),
-      user("Brian"),
-      user("Sheila")
-    )
-
+    
     val collaborators = Set(
       Collaborator("sample@email.com", CollaboratorRole.ADMINISTRATOR),
       Collaborator("someone@email.com", CollaboratorRole.DEVELOPER))
-
-    val allApplications = Seq(
-      ApplicationResponse(UUID.randomUUID(),
-        "application1", None, collaborators, DateTime.now(), ApplicationState()),
-      ApplicationResponse(UUID.randomUUID(),
-        "application2", None, collaborators, DateTime.now(), ApplicationState()),
-      ApplicationResponse(UUID.randomUUID(),
-        "application3", None, collaborators, DateTime.now(), ApplicationState())
-    )
-
-    val filteredApplications = Seq(
-      ApplicationResponse(UUID.randomUUID(),
-        "application1", None, collaborators, DateTime.now(), ApplicationState()),
-      ApplicationResponse(UUID.randomUUID(),
-        "application3", None, collaborators, DateTime.now(), ApplicationState())
-    )
-
-    given(testDeveloperService.applicationConnector.fetchAllApplications()(any[HeaderCarrier])).willReturn(
-      Future.successful(allApplications))
-    given(testDeveloperService.applicationConnector.fetchAllApplicationsBySubscription(
-      mEq("subscription"))(any[HeaderCarrier])).willReturn(Future.successful(filteredApplications))
   }
 
   "developerService" should {
     "list all developers when filtering not provided" in new Setup {
+      val users = Seq(user("Bob", false), user("Brian"), user("Sheila"))
+
+      val allApplications = Seq(
+        ApplicationResponse(UUID.randomUUID(),
+          "application1", None, collaborators, DateTime.now(), ApplicationState()),
+        ApplicationResponse(UUID.randomUUID(),
+          "application2", None, collaborators, DateTime.now(), ApplicationState()),
+        ApplicationResponse(UUID.randomUUID(),
+          "application3", None, collaborators, DateTime.now(), ApplicationState()))
+
+      given(testDeveloperService.applicationConnector.fetchAllApplications()(any[HeaderCarrier])).willReturn(Future.successful(allApplications))
       given(testDeveloperService.developerConnector.fetchAll()(any[HeaderCarrier])).willReturn(Future.successful(users))
       given(testDeveloperService.apiDefinitionConnector.fetchAll()(any[HeaderCarrier])).willReturn(Seq.empty[APIDefinition])
-
       val result: Seq[ApplicationResponse] = await(testDeveloperService.fetchApplications(AllUsers)(new HeaderCarrier()))
-
       result shouldEqual allApplications
     }
 
     "list filtered developers when filtering is provided" in new Setup {
+      val users = Seq(user("Bob", false), user("Brian"), user("Sheila"))
+
+      val filteredApplications = Seq(
+        ApplicationResponse(UUID.randomUUID(),
+          "application1", None, collaborators, DateTime.now(), ApplicationState()),
+        ApplicationResponse(UUID.randomUUID(),
+          "application3", None, collaborators, DateTime.now(), ApplicationState()))
+
+      given(testDeveloperService.applicationConnector.fetchAllApplicationsBySubscription(mEq("subscription"))(any[HeaderCarrier])).willReturn(Future.successful(filteredApplications))
       given(testDeveloperService.developerConnector.fetchAll()(any[HeaderCarrier])).willReturn(Future.successful(users))
       given(testDeveloperService.apiDefinitionConnector.fetchAll()(any[HeaderCarrier])).willReturn(Seq.empty[APIDefinition])
-
       val result = await(testDeveloperService.fetchApplications(Value("subscription"))(new HeaderCarrier()))
-
       result shouldBe filteredApplications
     }
 
     "Turn a list of users into an email list" in new Setup {
+      val users = Seq(user("Bob", false), user("Brian"), user("Sheila"))
       val result = testDeveloperService.emailList(users)
-
       result shouldBe "Bob@example.net; Brian@example.net; Sheila@example.net"
     }
 
-    "Get the list of users that have access to the given applications" in new Setup {
-      val _users = Seq(user("Bob"), user("Jim"), user("Jacob"))
-      val _allApplications = Seq(
+    "filter all users (no unregisted collaborators)" in new Setup {
+      val users = Seq(user("Bob"), user("Jim"), user("Jacob"))
+      val applications = Seq(
         app("application1", Set(
           Collaborator("Bob@example.net", CollaboratorRole.ADMINISTRATOR),
-          Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER)))
-      )
+          Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER))))
 
-      val result = testDeveloperService.filterUsersBy(AllUsers,_allApplications)(_users)
-      result shouldBe _users.filter{u => Set("Bob", "Jacob").contains(u.firstName)}
+      val result = testDeveloperService.filterUsersBy(AllUsers, applications)(users)
+      result shouldBe Seq( user("Bob"), user("Jim"), user("Jacob"))
     }
 
-    "Get the list of users that have access to different applications" in new Setup {
-      val _users = Seq( user("Bob"), user("Jim"), user("Jacob"))
-      val _allApplications = Seq(
+    "filter all users (including unregistered collaborators)" in new Setup {
+      val users = Seq( user("Bob"), user("Jim"), user("Jacob"))
+      val applications = Seq(
         app("application1", Set(
           Collaborator("Bob@example.net", CollaboratorRole.ADMINISTRATOR),
-          Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER)
-        )
-        ),
+          Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER))),
         app("application2", Set(
           Collaborator("Julia@example.net", CollaboratorRole.ADMINISTRATOR),
-          Collaborator("Jim@example.net", CollaboratorRole.DEVELOPER))
-        ))
+          Collaborator("Jim@example.net", CollaboratorRole.DEVELOPER))))
 
-      val result = testDeveloperService.filterUsersBy(AllUsers, _allApplications)(_users)
-      result shouldBe _users
+      val result = testDeveloperService.filterUsersBy(AllUsers, applications)(users)
+      result shouldBe Seq( user("Bob"), user("Jim"), user("Jacob"), UnregisteredCollaborator("Julia@example.net"))
     }
 
-    "No users in our list have access to these apps. Corner case - should never happen in the wild" in
+    "filter users that have access to 1 or more applications" in new Setup {
+      val users = Seq( user("Bob"), user("Jim"), user("Jacob"))
+      val applications = Seq(
+        app("application1", Set(
+          Collaborator("Bob@example.net", CollaboratorRole.ADMINISTRATOR),
+          Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER))),
+        app("application2", Set(
+          Collaborator("Julia@example.net", CollaboratorRole.ADMINISTRATOR),
+          Collaborator("Jim@example.net", CollaboratorRole.DEVELOPER))))
+
+      val result = testDeveloperService.filterUsersBy(OneOrMoreSubscriptions, applications)(users)
+      result shouldBe Seq( user("Bob"), user("Jim"), user("Jacob"), UnregisteredCollaborator("Julia@example.net"))
+    }
+
+    "filter users that are not associated with any applications" in
       new Setup {
-        val _users = Seq( user("Shirley"), user("Gaia"), user("Jimbob"))
-        val _allApplications = Seq(
+        val users = Seq( user("Shirley"), user("Gaia"), user("Jimbob"))
+        val applications = Seq(
           app("application1", Set(
-            Collaborator("Bob@example.net", CollaboratorRole.ADMINISTRATOR),
-            Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER)
-          )
-          ),
+            Collaborator("Shirley@example.net", CollaboratorRole.ADMINISTRATOR),
+            Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER))),
           app("application2", Set(
             Collaborator("Julia@example.net", CollaboratorRole.ADMINISTRATOR),
-            Collaborator("Jim@example.net", CollaboratorRole.DEVELOPER))
-          ))
+            Collaborator("Jim@example.net", CollaboratorRole.DEVELOPER))))
 
-        val result = testDeveloperService.filterUsersBy(AllUsers, _allApplications)(_users)
-        result shouldBe Seq()
+        val result = testDeveloperService.filterUsersBy(NoApplications, applications)(users)
+        result shouldBe Seq(user("Gaia"), user("Jimbob"))
       }
 
-    "No users in our list have access to empty app list." in new Setup {
-      val _users = Seq( user("Shirley"), user("Gaia"), user("Jimbob"))
-      val _allApplications = Seq()
-
-      val result = testDeveloperService.filterUsersBy(AllUsers, _allApplications)(_users)
-      result shouldBe Seq()
-    }
-
-    "fetch users who have no subscriptions" in new Setup {
-      val _users = Seq( user("Shirley"), user("Gaia"), user("Jimbob"), user("Jim"))
+    "filter users who have no subscriptions" in new Setup {
+      val users = Seq( user("Shirley"), user("Gaia"), user("Jimbob"), user("Jim"))
       val _allApplications = Seq(
         app("application1", Set(
           Collaborator("Bob@example.net", CollaboratorRole.ADMINISTRATOR),
-          Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER)
-        )
-        ),
+          Collaborator("Jacob@example.net", CollaboratorRole.DEVELOPER))),
         app("application2", Set(
           Collaborator("Julia@example.net", CollaboratorRole.ADMINISTRATOR),
-          Collaborator("Jim@example.net", CollaboratorRole.DEVELOPER))
-        ))
+          Collaborator("Jim@example.net", CollaboratorRole.DEVELOPER))))
 
-      val result = testDeveloperService.filterUsersBy(NoSubscriptions, _allApplications)(_users)
-      result shouldBe Seq(user("Shirley"), user("Gaia"), user("Jimbob"))
+      val result = testDeveloperService.filterUsersBy(NoSubscriptions, _allApplications)(users)
+      result shouldBe Seq(user("Jim"), UnregisteredCollaborator("Bob@example.net"), UnregisteredCollaborator("Jacob@example.net"), UnregisteredCollaborator("Julia@example.net"))
     }
 
     "filter by status does no filtering when any status" in new Setup {
+      val users = Seq(user("Bob", false), user("Brian"), user("Sheila"))
       val result = testDeveloperService.filterUsersBy(AnyStatus)(users)
       result shouldBe users
     }
 
     "filter by status only returns verified users when Verified status" in new Setup {
+      val users = Seq(user("Bob", false), user("Brian"), user("Sheila"))
       val result = testDeveloperService.filterUsersBy(VerifiedStatus)(users)
       result shouldBe Seq(user("Brian"), user("Sheila"))
     }
 
     "filter by status only returns unverified users when Unverified status" in new Setup {
+      val users = Seq(user("Bob", false), user("Brian"), user("Sheila"))
       val result = testDeveloperService.filterUsersBy(UnverifiedStatus)(users)
       result shouldBe Seq(user("Bob", verified = false))
     }


### PR DESCRIPTION
Changed the sense of what ALL, NONE mean in the API filter dropdown to expand to
* All users, regardless of whether they have apps, or those apps have subscriptions
* Users with apps subscribed to one or more APIs
* Users with apps not subscribed to any APIs
* Users without applications

Also, added an extra filter for unregistered collaborators

**NOTE:** This has a dependency on the latest _third-party-application_ which hasnt been merged just yet. This can be deployed ahead of that on the proviso that the NOSUB functionality won't work correctly. 