### PR TITLE
APIS-896 Addition of Stub run mode to GateKeeperFrontend

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -30,17 +30,6 @@ json.encryption {
   previousKeys = []
 }
 
-auditing {
-  enabled=true
-  traceRequests=true
-  consumer {
-    baseUri {
-      host = localhost
-      port = 8100
-    }
-  }
-}
-
 assets {
   version = "2.232.0"
   version = ${?ASSETS_FRONTEND_VERSION}
@@ -58,27 +47,147 @@ contact-frontend {
 
 devHubBaseUrl = "http://localhost:9680"
 
-microservice {
-  services {
-    auth {
-      host = localhost
-      port = 8500
-    }
+wiremock-port = 11111
+wiremock-port = ${?WIREMOCK_PORT}
 
-    third-party-application {
-      host = localhost
-      port = 9607
-    }
 
-    third-party-developer {
-      host = localhost
-      port = 9615
-    }
+Stub {
+  auditing {
+    enabled=false
+  }
 
-    api-definition{
-      host = localhost
-      port = 9604
+  microservice {
+    services {
+      auth {
+        host = localhost
+        port = 8500
+      }
+
+      third-party-application {
+        host = localhost
+        port = ${wiremock-port}
+      }
+
+      third-party-developer {
+        host = localhost
+        port = ${wiremock-port}
+      }
+
+      api-definition{
+        host = localhost
+        port = ${wiremock-port}
+      }
     }
   }
 }
 
+Dev {
+  auditing {
+    enabled = true
+    traceRequests = true
+    consumer {
+      baseUri {
+        host = localhost
+        port = 8100
+      }
+    }
+  }
+
+  microservice {
+    services {
+      auth {
+        host = localhost
+        port = 8500
+      }
+
+      third-party-application {
+        host = localhost
+        port = 9607
+      }
+
+      third-party-developer {
+        host = localhost
+        port = 9615
+      }
+
+      api-definition {
+        host = localhost
+        port = 9604
+      }
+    }
+  }
+}
+
+Test {
+  auditing {
+    enabled = true
+    traceRequests = true
+    consumer {
+      baseUri {
+        host = localhost
+        port = 8100
+      }
+    }
+  }
+
+  microservice {
+    services {
+      auth {
+        host = localhost
+        port = 8500
+      }
+
+      third-party-application {
+        host = localhost
+        port = 9607
+      }
+
+      third-party-developer {
+        host = localhost
+        port = 9615
+      }
+
+      api-definition {
+        host = localhost
+        port = 9604
+      }
+    }
+  }
+}
+
+Prod {
+  auditing {
+    enabled = true
+    traceRequests = true
+    consumer {
+      baseUri {
+        host = localhost
+        port = 8100
+      }
+    }
+  }
+
+  microservice {
+    services {
+      auth {
+        host = localhost
+        port = 8500
+      }
+
+      third-party-application {
+        host = localhost
+        port = 9607
+      }
+
+      third-party-developer {
+        host = localhost
+        port = 9615
+      }
+
+      api-definition {
+        host = localhost
+        port = 9604
+      }
+    }
+  }
+}

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sbt "run -Drun.mode=Stub"
+


### PR DESCRIPTION
Addition of multiple run.modes to allow the GateKeeperFrontend to be started in "Stub" which uses the API-Services-Stub to supply the Third Party Application & Developer resources.