### PR TITLE
Fix logback configuration based on latest templates

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,9 +5,9 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="DEBUG"/>
+    <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
 
-    <root level="INFO">
+    <root level="${logger.application:-WARN}">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/example-play-25-frontend.log</file>
+        <file>logs/api-gatekeeper-frontend.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
@@ -41,6 +41,10 @@
 
     <logger name="com.ning.http.client.providers.netty" additivity="false">
         <appender-ref ref="STDOUT_IGNORE_NETTY" />
+    </logger>
+
+    <logger name="com.google.inject" additivity="false">
+        <appender-ref ref="STDOUT_IGNORE_GUICE" />
     </logger>
 
     <logger name="uk.gov" level="INFO"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -43,9 +43,9 @@
         <appender-ref ref="STDOUT_IGNORE_NETTY" />
     </logger>
 
-    <logger name="com.google.inject" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_GUICE" />
-    </logger>
+    <logger name="com.google.inject" level="WARN"/>
+
+    <logger name="org.apache" level="WARN"/>
 
     <logger name="uk.gov" level="INFO"/>
 
@@ -55,7 +55,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,13 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/example-play-25-frontend.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+        </encoder>
     </appender>
 
-    <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+        </encoder>
+    </appender>
 
-    <root level="${logger.application:-WARN}">
+    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/access.log</file>
+        <encoder>
+            <pattern>%message%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/connector.log</file>
+        <encoder>
+            <pattern>%message%n</pattern>
+        </encoder>
+    </appender>
+
+
+    <logger name="accesslog" level="INFO" additivity="false">
+        <appender-ref ref="ACCESS_LOG_FILE" />
+    </logger>
+
+    <logger name="com.ning.http.client.providers.netty" additivity="false">
+        <appender-ref ref="STDOUT_IGNORE_NETTY" />
+    </logger>
+
+    <logger name="uk.gov" level="INFO"/>
+
+    <logger name="application" level="DEBUG"/>
+
+    <logger name="connector" level="TRACE">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Warnings are currently appearing in the build about logback configuration. This fix brings the config in-line with the latest guidance.