### PR TITLE
We use Logback over Slf4j for logging, dependencies fixed for that.

### DIFF
--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -18,6 +18,10 @@ private object AppDependencies {
 
   import play.core.PlayVersion
 
+  private val slf4jVersion = "1.7.22"
+  private val logbackVersion = "1.1.9"
+  private val log4j2AdapterVersion = "2.7"
+
   val compile = Seq(
     "uk.gov.hmrc" %% "frontend-bootstrap" % "7.10.0",
     "uk.gov.hmrc" %% "play-authorised-frontend" % "6.2.0",
@@ -27,8 +31,23 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "json-encryption" % "3.1.0",
     "uk.gov.hmrc" %% "play-health" % "2.0.0",
     "uk.gov.hmrc" %% "govuk-template" % "5.0.0",
-    "uk.gov.hmrc" %% "play-ui" % "5.3.0"
-  )
+    "uk.gov.hmrc" %% "play-ui" % "5.3.0",
+    "org.slf4j" % "slf4j-api" % slf4jVersion,
+    "org.slf4j" % "jcl-over-slf4j" % slf4jVersion,
+    "org.slf4j" % "jul-to-slf4j" % slf4jVersion,
+    "ch.qos.logback" % "logback-classic" % logbackVersion,
+    "ch.qos.logback" % "logback-core" % logbackVersion,
+    "org.apache.logging.log4j" % "log4j-to-slf4j" % log4j2AdapterVersion,
+    "org.apache.logging.log4j" % "log4j-1.2-api" % log4j2AdapterVersion,
+    "org.apache.logging.log4j" % "log4j-api" % log4j2AdapterVersion
+  ).map(
+    _.excludeAll(
+      ExclusionRule(organization = "commons-logging"),
+      ExclusionRule(organization = "log4j"),
+      ExclusionRule("org.apache.logging.log4j", "log4j-core"),
+      ExclusionRule("org.slf4j", "slf4j-log412"),
+      ExclusionRule("org.slf4j", "slf4j-jdk14")
+    ))
 
   abstract class TestDependencies(scope: String) {
     lazy val test: Seq[ModuleID] = Seq(
@@ -43,7 +62,14 @@ private object AppDependencies {
       "org.seleniumhq.selenium" % "selenium-htmlunit-driver" % "2.52.0" % scope,
       "org.mockito" % "mockito-all" % "1.10.19" % scope,
       "org.scalacheck" %% "scalacheck" % "1.12.6" % scope
-    )
+    ).map(
+      _.excludeAll(
+        ExclusionRule(organization = "commons-logging"),
+        ExclusionRule(organization = "log4j"),
+        ExclusionRule("org.apache.logging.log4j", "log4j-core"),
+        ExclusionRule("org.slf4j", "slf4j-log412"),
+        ExclusionRule("org.slf4j", "slf4j-jdk14")
+      ))
   }
 
   object Test extends TestDependencies("test")


### PR DESCRIPTION
Exclude other logging frameworks and instead use the slf4j bridge jars to log them over slf4j to logback.

## References:
* https://confluence.tools.tax.service.gov.uk/display/ApiPlatform/Logging+Dependencies
* http://www.slf4j.org/images/legacy.png
* http://stackoverflow.com/questions/25747900/is-there-a-simple-way-to-specify-a-global-dependency-exclude-in-sbt