### PR TITLE
Reduced logging when running tests

### DIFF
--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -7,7 +7,11 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <logger name="application" level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="ERROR">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/test/resources/logback.xml
+++ b/test/resources/logback.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="application" level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Note that `test/resources/logback.xml` overrides the standard logging settings used by FakeApplication.