### PR TITLE
APIS-4406 - DevelopersConnector uses new get-by-emails endpoint

### DIFF
--- a/test/unit/connectors/HttpDeveloperConnectorSpec.scala
+++ b/test/unit/connectors/HttpDeveloperConnectorSpec.scala
@@ -89,16 +89,21 @@ class HttpDeveloperConnectorSpec
       verifyUserResponse(result, developerEmailWithSpecialCharacter, "first", "last")
     }
 
-    "fetch all developers by emails" in new Setup {
-      val encodedEmailsParam = encode(s"$developerEmail,$developerEmailWithSpecialCharacter")
-      stubFor(get(urlEqualTo(s"/developers?emails=$encodedEmailsParam")).willReturn(
-        aResponse().withStatus(OK).withBody(
-          Json.toJson(Seq(aUserResponse(developerEmail), aUserResponse(developerEmailWithSpecialCharacter))).toString()))
+    "fetch all developers by emails (new)" in new Setup {
+      val postBody = Json.toJson(List(developerEmail, developerEmailWithSpecialCharacter))
+
+      stubFor(post(urlEqualTo(s"/developers/get-by-emails"))
+        .withRequestBody(equalToJson(postBody.toString))
+        .willReturn(
+          aResponse().withStatus(OK).withBody(
+            Json.toJson(Seq(aUserResponse(developerEmail), aUserResponse(developerEmailWithSpecialCharacter))).toString()))
       )
+
       val result = await(connector.fetchByEmails(Seq(developerEmail, developerEmailWithSpecialCharacter)))
       verifyUserResponse(result(0), developerEmail, "first", "last")
       verifyUserResponse(result(1), developerEmailWithSpecialCharacter, "first", "last")
     }
+
 
     "fetch all developers" in new Setup {
       stubFor(get(urlEqualTo("/developers/all")).willReturn(
@@ -135,7 +140,7 @@ class HttpDeveloperConnectorSpec
       result shouldBe user
     }
 
-    "search by email filter" in new Setup{
+    "search by email filter" in new Setup {
 
       val url = s"/developers?emailFilter=${encode(developerEmail)}"
       stubFor(get(urlEqualTo(url)).willReturn(

--- a/test/unit/connectors/WiremockSugar.scala
+++ b/test/unit/connectors/WiremockSugar.scala
@@ -18,6 +18,8 @@ package unit.connectors
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import org.scalatest.{BeforeAndAfterEach, Suite}
 
@@ -26,8 +28,11 @@ trait WiremockSugar extends BeforeAndAfterEach {
   val stubPort = sys.env.getOrElse("WIREMOCK", "22222").toInt
   val stubHost = "localhost"
   val wireMockUrl = s"http://$stubHost:$stubPort"
-  val wireMockServer = new WireMockServer(wireMockConfig()
-    .port(stubPort))
+
+  private val wireMockConfiguration: WireMockConfiguration =
+    wireMockConfig().port(stubPort)
+
+  val wireMockServer = new WireMockServer(wireMockConfiguration)
 
   override def beforeEach() = {
     wireMockServer.start()


### PR DESCRIPTION
 - This uses a post so lots of emails can be passed into third-party-developer endpoint, without hitting long URI limits