### PR TITLE
APIS-4484 - Added a missing test verify 

### DIFF
--- a/test/services/ApplicationServiceSpec.scala
+++ b/test/services/ApplicationServiceSpec.scala
@@ -544,6 +544,8 @@ class ApplicationServiceSpec extends UnitSpec with MockitoSugar {
       val result = await(underTest.fetchApplicationSubscriptions(stdApp1))
 
       result shouldBe subscriptions
+
+      verify(mockSubscriptionFieldsService,never()).fetchAllFieldDefinitions(any())(any[HeaderCarrier])
     }
 
     "fetch subscriptions with fields" in new SubscriptionFieldsServiceSetup {


### PR DESCRIPTION
Added a missing test verify for when not loading the subscription field definitions.