### PR TITLE
APIS-5542 : Fix default button on search apps page

### DIFF
--- a/app/assets/stylesheets/partials/ad-hoc.scss
+++ b/app/assets/stylesheets/partials/ad-hoc.scss
@@ -176,5 +176,6 @@ p.error-notification {
 
 .appsearch-buttons {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  flex-direction: row-reverse;
 }

--- a/app/views/applications/ApplicationsView.scala.html
+++ b/app/views/applications/ApplicationsView.scala.html
@@ -151,11 +151,13 @@ implicit loggedInUser: LoggedInUser, messagesProvider: MessagesProvider)
                     
                     <input type="hidden" value="@showExport" name="showExport"/>
 
+                    <!-- These two inputs are reversed in the html dom as the first submit button is trigged by the 'enter' key on the 
+                    text search input'. They are then swapped in the stylesheet. -->
+                    <input type="submit" value="Submit" name="main-submit" class="button plain-button"/>
+
                     @if(showExport==Some("true")){
                         <input id="submitButton" type="submit" value="Export CSV" name="submit" formaction="@routes.ApplicationController.applicationsPageCsv(None).url" class="button"/>
                     }
-                    
-                    <input type="submit" value="Submit" name="main-submit" class="button plain-button"/>
                 </div>
                 <br/>
                 <table id="applications-table" class="no-footer application-list" width="100%">


### PR DESCRIPTION
- The default button on a text box in a html form is the first input
submit element in the dom. We want the 'export CSV' button to be
visual first on the page, but not the default. So they are swapped
visually in the style sheet.