### PR TITLE
API-5169 - Fixed Json formatting errors on APICategory

### DIFF
--- a/app/controllers/EmailsController.scala
+++ b/app/controllers/EmailsController.scala
@@ -18,6 +18,7 @@ package controllers
 
 import config.AppConfig
 import model.Forms._
+
 import javax.inject.{Inject, Singleton}
 import model.DeveloperStatusFilter.VerifiedStatus
 import model.EmailOptionChoice.{EMAIL_ALL_USERS, _}
@@ -37,10 +38,10 @@ import uk.gov.hmrc.modules.stride.controllers.actions.ForbiddenHandler
 import uk.gov.hmrc.modules.stride.connectors.AuthConnector
 
 import scala.concurrent.{ExecutionContext, Future}
-
 import model.{RegisteredUser, User}
 import play.api.libs.json.Json
 import model.CombinedApi
+import model.CombinedApiCategory.toAPICategory
 
 
 @Singleton
@@ -128,7 +129,7 @@ class EmailsController @Inject()(
         apis <- apmService.fetchAllCombinedApis()
         filteredApis = filterSelectedApis(Some(selectedAPIs), apis).sortBy(_.displayName)
         apiNames = filteredApis.map(_.serviceName)
-        categories = filteredApis.flatMap(_.categories)
+        categories = filteredApis.flatMap(_.categories.map(toAPICategory))
         users <- selectedTopic.fold(Future.successful(List.empty[RegisteredUser]))(topic => {
           developerService.fetchDevelopersBySpecificAPIEmailPreferences(topic, categories, apiNames).map(_.filter(_.verified))
         })

--- a/app/model/CombinedApi.scala
+++ b/app/model/CombinedApi.scala
@@ -17,7 +17,7 @@
 package model
 
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 
 sealed trait ApiType extends EnumEntry
@@ -28,9 +28,18 @@ object ApiType extends Enum[ApiType] with PlayJsonEnum[ApiType] {
   case object XML_API extends ApiType
 }
 
+case class CombinedApiCategory(value: String) extends AnyVal
+
+object CombinedApiCategory {
+  implicit val categoryFormat: Format[CombinedApiCategory] = Json.format[CombinedApiCategory]
+  def toAPICategory(combinedApiCategory: CombinedApiCategory) : APICategory = {
+    APICategory(combinedApiCategory.value)
+  }
+}
+
 case class CombinedApi(displayName: String,
                        serviceName: String,
-                        categories: List[APICategory],
+                        categories: List[CombinedApiCategory],
                         apiType: ApiType)
 
 object CombinedApi {

--- a/app/views/emails/EmailPreferencesSpecificApiView.scala.html
+++ b/app/views/emails/EmailPreferencesSpecificApiView.scala.html
@@ -24,6 +24,12 @@
 
 @(users: List[RegisteredUser], composeEmailRecipients: JsValue, emails: String,  filteredApis: List[CombinedApi], maybeTopicFilter: Option[TopicOptionChoice])(implicit request: Request[_], loggedInUser: LoggedInUser, messagesProvider: MessagesProvider)
 
+    @handleAppendXmlTag(api: CombinedApi) =@{
+        if(api.apiType == ApiType.XML_API) {
+            api.displayName + " - XML API"
+        } else { api.displayName }
+    }
+
     @main(title = s"${applicationConfig.title} - Email users interested in a specific API") {
 
         <div class="govuk-template__body">
@@ -42,12 +48,12 @@
                             @for(filteredApi <- filteredApis) {
                                 <li class="hmrc-add-to-a-list__contents">
                                     <span class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
-                                    @filteredApi.displayName
+                                        @handleAppendXmlTag(filteredApi)
                                     </span>
                                     <span class="hmrc-add-to-a-list__remove">
                                         <a class="govuk-link" href="@routes.EmailsController.emailPreferencesSpecificApis(filteredApis.filterNot(_.equals(filteredApi)).map(_.serviceName), None).url">
                                             <span aria-hidden="true">Remove</span>
-                                            <span class="govuk-visually-hidden">Remove @filteredApi.displayName from the list</span>
+                                            <span class="govuk-visually-hidden">Remove @handleAppendXmlTag(filteredApi) from the list</span>
                                         </a>
                                     </span>
                                     <span><input type="hidden" name="selectedAPIs" value="@filteredApi.serviceName"/></span>

--- a/test/connectors/ApmConnectorSpec.scala
+++ b/test/connectors/ApmConnectorSpec.scala
@@ -55,8 +55,8 @@ class ApmConnectorSpec
 
     val underTest = new ApmConnector(httpClient, mockApmConnectorConfig)
 
-    val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(APICategory("CUSTOMS")), ApiType.REST_API)
-    val combinedXmlApi2 = CombinedApi("displayName2", "serviceName2", List(APICategory("VAT")), ApiType.XML_API)
+    val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(CombinedApiCategory("CUSTOMS")), ApiType.REST_API)
+    val combinedXmlApi2 = CombinedApi("displayName2", "serviceName2", List(CombinedApiCategory("VAT")), ApiType.XML_API)
     val combinedList = List(combinedRestApi1, combinedXmlApi2)
   }
 

--- a/test/controllers/EmailsControllerSpec.scala
+++ b/test/controllers/EmailsControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import akka.stream.Materializer
+import model.CombinedApiCategory.toAPICategory
 import model.EmailOptionChoice.{API_SUBSCRIPTION, EMAIL_ALL_USERS, EMAIL_PREFERENCES, EmailOptionChoice}
 import model.EmailPreferencesChoice.{EmailPreferencesChoice, SPECIFIC_API, TAX_REGIME, TOPIC}
 import model._
@@ -114,8 +115,8 @@ class EmailsControllerSpec extends ControllerBaseSpec with WithCSRFAddToken with
         ApiCategories.returns(category1, category2, category3)
       }
 
-      val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(APICategory("CUSTOMS")), ApiType.REST_API)
-      val combinedXmlApi2 = CombinedApi("displayName2", "serviceName2", List(APICategory("VAT")), ApiType.XML_API)
+      val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(CombinedApiCategory("CUSTOMS")), ApiType.REST_API)
+      val combinedXmlApi2 = CombinedApi("displayName2", "serviceName2", List(CombinedApiCategory("VAT")), ApiType.XML_API)
       val combinedList = List(combinedRestApi1, combinedXmlApi2)
 
       val underTest = new EmailsController(
@@ -368,7 +369,7 @@ class EmailsControllerSpec extends ControllerBaseSpec with WithCSRFAddToken with
         status(result) shouldBe OK
         val apiNames = selectedAPIs.map(_.serviceName)
 
-        val  categories = selectedAPIs.flatMap(_.categories)
+        val  categories = selectedAPIs.flatMap(_.categories.map(toAPICategory))
 
         verify(mockApmService).fetchAllCombinedApis()(*)
         verify(mockDeveloperService).fetchDevelopersBySpecificAPIEmailPreferences(eqTo(selectedTopic), eqTo(categories), eqTo(apiNames))(*)

--- a/test/services/ApmServiceSpec.scala
+++ b/test/services/ApmServiceSpec.scala
@@ -36,14 +36,14 @@ class ApmServiceSpec extends AsyncHmrcSpec {
     val combinedRestApi1 = CombinedApi(
       "displayName1",
       "serviceName1",
-      List(APICategory("CUSTOMS")),
+      List(CombinedApiCategory("CUSTOMS")),
       ApiType.REST_API
     )
 
     val combinedXmlApi2 = CombinedApi(
       "displayName2",
       "serviceName2",
-      List(APICategory("VAT")),
+      List(CombinedApiCategory("VAT")),
       ApiType.XML_API
     )
     val combinedList = List(combinedRestApi1, combinedXmlApi2)

--- a/test/views/emails/EmailPreferencesSelectApiViewSpec.scala
+++ b/test/views/emails/EmailPreferencesSelectApiViewSpec.scala
@@ -25,9 +25,7 @@ import play.twirl.api.HtmlFormat
 import utils.FakeRequestCSRFSupport._
 import views.CommonViewSpec
 import views.html.emails.EmailPreferencesSelectApiView
-import model.CombinedApi
-import model.APICategory
-import model.ApiType
+import model.{ApiType, CombinedApi, CombinedApiCategory}
 
 class EmailPreferencesSelectApiViewSpec extends CommonViewSpec with EmailPreferencesSelectAPIViewHelper{
 
@@ -44,8 +42,8 @@ class EmailPreferencesSelectApiViewSpec extends CommonViewSpec with EmailPrefere
      val api3 = simpleAPI(serviceName="serviceName2", displayName="displayName2",  List.empty,  ApiType.XML_API)
      val dropDownApis = Seq(api1, api2, api3)
 
-    val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(APICategory("CUSTOMS")), ApiType.REST_API)
-    val combinedXmlApi3 = CombinedApi("displayName2", "serviceName2", List(APICategory("VAT")), ApiType.XML_API)
+    val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(CombinedApiCategory("CUSTOMS")), ApiType.REST_API)
+    val combinedXmlApi3 = CombinedApi("displayName2", "serviceName2", List(CombinedApiCategory("VAT")), ApiType.XML_API)
     val combinedList = List(combinedRestApi1, combinedXmlApi3)
 
     "show correct title and options when no selectedAPis provided" in new Setup {

--- a/test/views/emails/EmailPreferencesSpecificApiViewSpec.scala
+++ b/test/views/emails/EmailPreferencesSpecificApiViewSpec.scala
@@ -38,12 +38,10 @@ class EmailPreferencesSpecificApiViewSpec extends CommonViewSpec with EmailPrefe
 
   "email preferences specific api view" must {
     val selectedTopic = TopicOptionChoice.BUSINESS_AND_POLICY
-    val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(APICategory("CUSTOMS")), ApiType.REST_API)
-    val combinedXmlApi2 = CombinedApi("displayName2", "serviceName2", List(APICategory("VAT")), ApiType.XML_API)
+    val combinedRestApi1 = CombinedApi("displayName1", "serviceName1", List(CombinedApiCategory("CUSTOMS")), ApiType.REST_API)
+    val combinedXmlApi2 = CombinedApi("displayName2", "serviceName2", List(CombinedApiCategory("VAT")), ApiType.XML_API)
     val combinedList = List(combinedRestApi1, combinedXmlApi2)
 
-    // val selectedApis: List[ApiDefinition] = List(simpleAPIDefinition("Api1ServiceName", "Api1Name", "context", None, "1"),
-    //   simpleAPIDefinition("Api2ServiceName", "Api2Name", "context",  None, "1"))
     val user1 = RegisteredUser("user1@hmrc.com", UserId.random, "userA", "1", verified = true)
     val user2 = RegisteredUser("user2@hmrc.com", UserId.random, "userB", "2", verified = true)
     val users = List(user1, user2)

--- a/testCommon/views/emails/CombinedApiHelper.scala
+++ b/testCommon/views/emails/CombinedApiHelper.scala
@@ -16,14 +16,12 @@
 
 package views.emails
 
-import model.CombinedApi
-import model.ApiType
-import model.APICategory
+import model.{ApiType, CombinedApi, CombinedApiCategory}
 
 trait CombinedApiHelper {
    def simpleAPI(serviceName: String,
                           displayName: String,
                           categories: List[String],
                           apiType: ApiType): CombinedApi =
-    CombinedApi(displayName, serviceName,  categories.map(APICategory(_)), apiType)
+    CombinedApi(displayName, serviceName,  categories.map(CombinedApiCategory(_)), apiType)
 }


### PR DESCRIPTION
Decoupled CombinedApi from (APIDefinition's) APICategory by creating CombinedApiCategory
Postfixed "XML API" to XML API display names on Specific API view