### PR TITLE
API-7664: show no-refresh-token option

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,7 +64,7 @@ retryCount = 3
 retryDelayMilliseconds = 500
 
 api-gatekeeper-approvals-frontend.enabled = false
-application.grantlength.norefreshtoken.shown = false
+application.grantlength.norefreshtoken.shown = true
 
 internal-auth.token = "9684"
 


### PR DESCRIPTION
Until we remove the logic that uses this value to hide the option